### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,11 @@ module.exports = (eleventyConfig) => {
 Get your scss on in templates with a shortcode (this example uses handlebars):
 
 ```
-{{#javascript}}  
-  console.log("hello world!");
-{{/javascript}}`
+{{# scss}}  
+  body {
+    color: red;
+  }
+{{/ scss}}`
 ```
 
 ## Todo: 


### PR DESCRIPTION
the example shortcode was for javascript, but the shortcode included with this plugin is for scss